### PR TITLE
Update .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -12,6 +12,18 @@ lib-cov
 
 # Coverage directory used by tools like istanbul
 coverage
+.nyc_output/
+.nycrc
+
+# GitHub actions
+.github/
+
+# eslint configuration
+.eslintignore
+.eslintrc
+
+# tests
+test/
 
 # Grunt intermediate storage (http://gruntjs.com/creating-plugins#storing-task-files)
 .grunt


### PR DESCRIPTION
To not include coverage output, config files, tests, and github actions.

Compressed package size goes from 8.1 kB to 4.0 kB.
Uncompressed package size goes from 36.7 kB to 10.5 kB

to check, run `npm pack --dry-run`

